### PR TITLE
remove missing method call for getHistory

### DIFF
--- a/src/Extension/Context/ApiTrait.php
+++ b/src/Extension/Context/ApiTrait.php
@@ -28,8 +28,7 @@ trait ApiTrait
     /** {@inheritDoc} */
     public function getResponse(): ResponseInterface
     {
-        $history = $this->getHistory();
-        $response = $history->getLastResponse();
+        $response = $this->history->getLastResponse();
 
         if (!$response instanceof ResponseInterface) {
             throw new RuntimeException('No response');
@@ -38,4 +37,3 @@ trait ApiTrait
         return $response;
     }
 }
-


### PR DESCRIPTION
`ApiTrait::getHistory`  does not exists. `history` is directly accessible.