### PR TITLE
add missing call to the parent's constructor

### DIFF
--- a/src/Context/Json.php
+++ b/src/Context/Json.php
@@ -16,6 +16,7 @@ class Json extends AbstractJson implements ApiInterface
 
     public function __construct(LastHistory $history)
     {
+        parent::__construct();
         $this->history = $history;
     }
 


### PR DESCRIPTION
Without this call, the `accessor` [[1]](https://github.com/Taluu/Behapi/blob/master/src/Context/AbstractJson.php#L23) is never created