### PR TITLE
Do not reset the history in Rest context

### DIFF
--- a/src/Context/Rest.php
+++ b/src/Context/Rest.php
@@ -238,7 +238,7 @@ class Rest implements ApiInterface, Context, TwigInterface
     {
         $this->query = [];
         $this->request = null;
-        $this->history->reset();
+        // the history is resetted in its own event listener
     }
 
     /**


### PR DESCRIPTION
Removed the call to `LastHistory::reset()` in the Rest context. as it is already handled in the `Cleaner` subscriber, which is called _after_ all the `@AfterScenario` annotated "contexts"

Fix #17

cc @krichprollsch 