### PR TITLE
Change LastHistory::$lastResponse default value

### DIFF
--- a/src/Extension/Tools/LastHistory.php
+++ b/src/Extension/Tools/LastHistory.php
@@ -15,7 +15,7 @@ class LastHistory implements Journal
     private $lastRequest = null;
 
     /** @var ResponseInterface */
-    private $lastResponse = [];
+    private $lastResponse = null;
 
     /** {@inheritDoc} */
     public function addSuccess(RequestInterface $request, ResponseInterface $response)


### PR DESCRIPTION
Otherwise, if an error occurs and the `lastResponse` is not filled and we try to access it via `$history->getLastResponse()`, php7 cries thanks to the typehint.

This fixes that.