### PR TITLE
Rename the Rest context to Http

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 Behapi
 ======
-Behat extension to help write describe features related to Rest APIs (and more)
+Behat extension to help write describe features related to HTTP APIs.
 
 PHP 7.1 and Behat 3.3, and a discoverable php-http client are required to make
 this extension work.
 
 Installing this extension is pretty easy, and there are multiple ways to do
 that ; but the one exposed here is the best (this is pretty subjective), which
-is via Composer. You just need to require `taluu/behapi` and an implementation 
-of a http/client (providing `php-http/client-implementation ^1.0`)  and it's 
+is via Composer. You just need to require `taluu/behapi` and an implementation
+of a http/client (providing `php-http/client-implementation ^1.0`)  and it's
 done !
 
 Howto
@@ -32,7 +32,7 @@ have twig installed** ; Use the `--config-reference` flag when invoking behat
 to have more information on the available configuration.
 
 After having installed the extension, you can then use the provided contexts
-such as the `Behapi\Context\Rest` for the rest operations. In order to use
+such as the `Behapi\Context\Http` for the http api operations. In order to use
 them, you need to use behapi's container (`@behapi.container`, see example in
 the `behat.yml.dist` file), or a container capable of using behapi's container.
 

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -5,7 +5,7 @@ default:
       services: "@behapi.container"
 
       contexts:
-        - Behapi\Context\Rest:
+        - Behapi\Context\Http:
           - "@http.client"
           - "@http.stream_factory"
           - "@http.message_factory"

--- a/src/Context/Http.php
+++ b/src/Context/Http.php
@@ -20,7 +20,7 @@ use Behapi\Extension\Context\TwigTrait;
 use Behapi\Extension\Tools\Assert;
 use Behapi\Extension\Tools\HttpHistory;
 
-class Rest implements Context
+class Http implements Context
 {
     use ApiTrait;
     use TwigTrait;


### PR DESCRIPTION
Because this context does much more than "Rest" requests, it actually does http requests.