### PR TITLE
Twig "improvements"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,6 +52,8 @@
 
         "nyholm/psr7": "^0.2",
 
+        "twig/twig": "^2.0",
+
         "php-http/message": "^1.0",
         "php-http/mock-client": "^0.3"
     }

--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,10 @@
         "twig/twig": "In order to use the Twig template in some contexts"
     },
 
+    "conflict": {
+        "twig/twig": "< 1.2"
+    },
+
     "prefer-stable": true,
     "minimum-stability": "dev",
 

--- a/src/Context/TwigTrait.php
+++ b/src/Context/TwigTrait.php
@@ -14,7 +14,7 @@ trait TwigTrait
             return $string;
         }
 
-        $key = sprintf('__behapi_tpl__%s', hash('sha256', $string));
+        $key = sprintf('__behapi_tpl__%s', sha1($string));
 
         // this is assuming that the loader is Twig_Loader_Array
         // as this was privately set in the initializer, it should be OK


### PR DESCRIPTION
Added a constraint on twig, to ensure that `Twig_Loader_Array` is available (from 1.2.0, which was a while ago). I was pondering on using namespaces (>= 1.34 || >= 2.0), but the value does not seem to be worth it.

I also added twig as a dev dependency, and used a good old `sha1`, because `sha256` is overkill and this hash doesn't really have any security implications (it's just a generation of the "template filename", really...).