### PR TITLE
Event dispatcher

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,9 @@
         "php": "^7.1",
 
         "webmozart/assert": "^1.2",
+
         "symfony/property-access": "^3.1 || ^4.0",
+        "symfony/event-dispatcher": "^3.4 || ^4.0",
 
         "psr/http-message": "^1.0",
         "psr/http-message-implementation": "^1.0",

--- a/src/Container.php
+++ b/src/Container.php
@@ -5,6 +5,9 @@ use Psr\Container\ContainerInterface;
 
 use Behat\Behat\HelperContainer\Exception\ServiceNotFoundException;
 
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
 use Http\Message\StreamFactory;
 use Http\Message\MessageFactory;
 
@@ -49,6 +52,7 @@ final class Container implements ContainerInterface
             HttpHistory::class,
             StreamFactory::class,
             MessageFactory::class,
+            EventDispatcherInterface::class,
         ];
 
         return in_array($id, $services);
@@ -70,6 +74,9 @@ final class Container implements ContainerInterface
 
             case StreamFactory::class:
                 return $this->services[$id] = StreamFactoryDiscovery::find();
+
+            case EventDispatcherInterface::class:
+                return $this->services[$id] = new EventDispatcher;
         }
 
         throw new ServiceNotFoundException("Service {$id} is not available", $id);

--- a/src/Context/Http.php
+++ b/src/Context/Http.php
@@ -8,6 +8,8 @@ use Psr\Http\Message\RequestInterface;
 use Behat\Behat\Context\Context;
 use Behat\Gherkin\Node\TableNode;
 
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
 use Http\Client\HttpClient;
 use Http\Message\StreamFactory;
 use Http\Message\MessageFactory;
@@ -27,10 +29,14 @@ class Http implements Context
     /** @var mixed[] Query args to add */
     private $query;
 
-    public function __construct(HttpClient $client, StreamFactory $streamFactory, MessageFactory $messageFactory, HttpHistory $history)
+    /** @var EventDispatcherInterface */
+    private $dispatcher;
+
+    public function __construct(HttpClient $client, StreamFactory $streamFactory, MessageFactory $messageFactory, HttpHistory $history, EventDispatcherInterface $dispatcher)
     {
         $this->client = $client;
         $this->history = $history;
+        $this->dispatcher = $dispatcher;
         $this->streamFactory = $streamFactory;
         $this->messageFactory = $messageFactory;
     }

--- a/src/Context/Http.php
+++ b/src/Context/Http.php
@@ -16,6 +16,9 @@ use Http\Message\MessageFactory;
 
 use Behapi\Context\ApiTrait;
 
+use Behapi\EventListener\Events;
+use Behapi\EventListener\RequestEvent;
+
 use Behapi\Tools\Assert;
 use Behapi\Tools\HttpHistory;
 
@@ -147,6 +150,7 @@ class Http implements Context
             $request = $request->withUri($uri);
         }
 
+        $this->dispatcher->dispatch(Events::REQUEST_PRE_SENDING, new RequestEvent($request));
         $this->client->sendRequest($request);
     }
 

--- a/src/EventListener/Events.php
+++ b/src/EventListener/Events.php
@@ -3,6 +3,8 @@ namespace Behapi\EventListener;
 
 final class Events
 {
+    const REQUEST_PRE_SENDING = 'request.pre_sending';
+
     private function __construct()
     {
     }

--- a/src/EventListener/Events.php
+++ b/src/EventListener/Events.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+namespace Behapi\EventListener;
+
+final class Events
+{
+    private function __construct()
+    {
+    }
+
+    private function __clone()
+    {
+    }
+}

--- a/src/EventListener/RequestEvent.php
+++ b/src/EventListener/RequestEvent.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+namespace Behapi\EventListener;
+
+use Psr\Http\Message\RequestInterface;
+
+use Symfony\Component\EventDispatcher\Event;
+
+final class RequestEvent extends Event
+{
+    /** @var RequestInterface */
+    private $request;
+
+    public function __construct(RequestInterface $request)
+    {
+        $this->request = $request;
+    }
+
+    public function getRequest(): RequestInterface
+    {
+        return $this->request;
+    }
+}


### PR DESCRIPTION
Add an event dispatcher with "some" events (one for now actually).

I was pondering if adding a `POST_SENDING` event would be useful, but I'm not sure. So I didn't do it.

Should fix #41 

I choose *not* to be able to add listeners / subscribers through the config ; if you need to register a subscriber / listener, use the `EventDispatcherInterface` service and register what you need in there.