### PR TITLE
Notion of intropection for debug

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,8 @@
     },
 
     "suggest": {
-        "coduo/php-matcher": "In order to use the PHP Matcher context"
+        "coduo/php-matcher": "In order to use the PHP Matcher context",
+        "symfony/var-dumper": "In order to use the VarDumper debug dumper"
     },
 
     "conflict": {
@@ -57,6 +58,8 @@
         "coduo/php-matcher": "^2.3 || ^3.0",
 
         "php-http/message": "^1.0",
-        "php-http/mock-client": "^0.3"
+        "php-http/mock-client": "^0.3",
+
+        "symfony/var-dumper": "^2.8 || ^3.3 || ^4.0"
     }
 }

--- a/src/Behapi.php
+++ b/src/Behapi.php
@@ -45,6 +45,7 @@ final class Behapi implements Extension
                     ->children()
                         ->scalarNode('formatter')
                             ->defaultValue('pretty')
+                            ->info('Not used anymore, only here for BC')
                         ->end()
 
                         ->arrayNode('headers')
@@ -137,9 +138,7 @@ final class Behapi implements Extension
         ;
 
         $container->register(Debug\CliController::class, Debug\CliController::class)
-            ->addArgument(new Reference('output.manager'))
             ->addArgument(new Reference(Debug\Configuration::class))
-            ->addArgument($config['formatter'])
 
             ->setPublic(false)
             ->addTag(CliExtension::CONTROLLER_TAG, ['priority' => 10])

--- a/src/Behapi.php
+++ b/src/Behapi.php
@@ -77,32 +77,8 @@ final class Behapi implements Extension
     /** {@inheritDoc} */
     public function load(ContainerBuilder $container, array $config)
     {
-        $container->register(Debug\Configuration::class, Debug\Configuration::class)
-            ->addArgument($config['debug']['headers']['request'])
-            ->addArgument($config['debug']['headers']['response'])
-
-            ->setPublic(false)
-        ;
-
         $container->register(HttpHistory\History::class, HttpHistory\History::class)
             ->setPublic(false)
-        ;
-
-        $container->register(Debug\CliController::class, Debug\CliController::class)
-            ->addArgument(new Reference('output.manager'))
-            ->addArgument(new Reference(Debug\Configuration::class))
-            ->addArgument($config['debug']['formatter'])
-
-            ->setPublic(false)
-            ->addTag(CliExtension::CONTROLLER_TAG, ['priority' => 10])
-        ;
-
-        $container->register(Debug\Listener::class, Debug\Listener::class)
-            ->addArgument(new Reference(Debug\Configuration::class))
-            ->addArgument(new Reference(HttpHistory\History::class))
-
-            ->setPublic(false)
-            ->addTag('event_dispatcher.subscriber')
         ;
 
         $container->register(HttpHistory\Listener::class, HttpHistory\Listener::class)
@@ -112,6 +88,7 @@ final class Behapi implements Extension
             ->addTag('event_dispatcher.subscriber')
         ;
 
+        $this->loadDebugServices($container, $config['debug']);
         $this->loadContainer($container, $config);
     }
 
@@ -133,5 +110,32 @@ final class Behapi implements Extension
         $definition->setShared(false);
 
         $definition->addTag(HelperContainerExtension::HELPER_CONTAINER_TAG);
+    }
+
+    private function loadDebugServices(ContainerBuilder $container, array $config): void
+    {
+        $container->register(Debug\Configuration::class, Debug\Configuration::class)
+            ->addArgument($config['headers']['request'])
+            ->addArgument($config['headers']['response'])
+
+            ->setPublic(false)
+        ;
+
+        $container->register(Debug\CliController::class, Debug\CliController::class)
+            ->addArgument(new Reference('output.manager'))
+            ->addArgument(new Reference(Debug\Configuration::class))
+            ->addArgument($config['formatter'])
+
+            ->setPublic(false)
+            ->addTag(CliExtension::CONTROLLER_TAG, ['priority' => 10])
+        ;
+
+        $container->register(Debug\Listener::class, Debug\Listener::class)
+            ->addArgument(new Reference(Debug\Configuration::class))
+            ->addArgument(new Reference(HttpHistory\History::class))
+
+            ->setPublic(false)
+            ->addTag('event_dispatcher.subscriber')
+        ;
     }
 }

--- a/src/Behapi.php
+++ b/src/Behapi.php
@@ -156,8 +156,16 @@ final class Behapi implements Extension
             ->addTag(self::DEBUG_INTROSPECTION_TAG, ['priority' => -100])
         ;
 
+        $container->register(Debug\Introspection\Request\VarDumperAdapter::class, Debug\Introspection\Request\VarDumperAdapter::class)
+            ->addTag(self::DEBUG_INTROSPECTION_TAG, ['priority' => -80])
+        ;
+
         $container->register(Debug\Introspection\Response\EchoerAdapter::class, Debug\Introspection\Response\EchoerAdapter::class)
             ->addTag(self::DEBUG_INTROSPECTION_TAG, ['priority' => -100])
+        ;
+
+        $container->register(Debug\Introspection\Response\VarDumperAdapter::class, Debug\Introspection\Response\VarDumperAdapter::class)
+            ->addTag(self::DEBUG_INTROSPECTION_TAG, ['priority' => -80])
         ;
     }
 }

--- a/src/Behapi.php
+++ b/src/Behapi.php
@@ -22,6 +22,8 @@ use Behapi\HttpHistory;
  */
 final class Behapi implements Extension
 {
+    const DEBUG_INTROSPECTION_TAG = 'behapi.debug.introspection';
+
     /** {@inheritDoc} */
     public function getConfigKey()
     {
@@ -95,6 +97,19 @@ final class Behapi implements Extension
     /** {@inheritDoc} */
     public function process(ContainerBuilder $container)
     {
+        $dumpers = [];
+
+        foreach ($container->findTaggedServiceIds(self::DEBUG_INTROSPECTION_TAG) as $id => $tags) {
+            foreach ($tags as $attributes) {
+                $priority = $attributes['priority'] ?? 0;
+                $dumpers[$priority][] = new Reference($id);
+            }
+        }
+
+        krsort($dumpers);
+
+        $container->getDefinition(Debug\Listener::class)
+            ->addArgument(array_merge(...$dumpers));
     }
 
     private function loadContainer(ContainerBuilder $container, array $config): void

--- a/src/Behapi.php
+++ b/src/Behapi.php
@@ -152,5 +152,13 @@ final class Behapi implements Extension
             ->setPublic(false)
             ->addTag('event_dispatcher.subscriber')
         ;
+
+        $container->register(Debug\Introspection\Request\EchoerAdapter::class, Debug\Introspection\Request\EchoerAdapter::class)
+            ->addTag(self::DEBUG_INTROSPECTION_TAG, ['priority' => -100])
+        ;
+
+        $container->register(Debug\Introspection\Response\EchoerAdapter::class, Debug\Introspection\Response\EchoerAdapter::class)
+            ->addTag(self::DEBUG_INTROSPECTION_TAG, ['priority' => -100])
+        ;
     }
 }

--- a/src/Behapi.php
+++ b/src/Behapi.php
@@ -160,12 +160,20 @@ final class Behapi implements Extension
             ->addTag(self::DEBUG_INTROSPECTION_TAG, ['priority' => -80])
         ;
 
+        $container->register(Debug\Introspection\Request\VarDumper\JsonAdapter::class, Debug\Introspection\Request\VarDumper\JsonAdapter::class)
+            ->addTag(self::DEBUG_INTROSPECTION_TAG, ['priority' => -75])
+        ;
+
         $container->register(Debug\Introspection\Response\EchoerAdapter::class, Debug\Introspection\Response\EchoerAdapter::class)
             ->addTag(self::DEBUG_INTROSPECTION_TAG, ['priority' => -100])
         ;
 
         $container->register(Debug\Introspection\Response\VarDumperAdapter::class, Debug\Introspection\Response\VarDumperAdapter::class)
             ->addTag(self::DEBUG_INTROSPECTION_TAG, ['priority' => -80])
+        ;
+
+        $container->register(Debug\Introspection\Response\VarDumper\JsonAdapter::class, Debug\Introspection\Response\VarDumper\JsonAdapter::class)
+            ->addTag(self::DEBUG_INTROSPECTION_TAG, ['priority' => -70])
         ;
     }
 }

--- a/src/Behapi.php
+++ b/src/Behapi.php
@@ -152,28 +152,21 @@ final class Behapi implements Extension
             ->addTag('event_dispatcher.subscriber')
         ;
 
-        $container->register(Debug\Introspection\Request\EchoerAdapter::class, Debug\Introspection\Request\EchoerAdapter::class)
-            ->addTag(self::DEBUG_INTROSPECTION_TAG, ['priority' => -100])
-        ;
+        $adapters = [
+            Debug\Introspection\Request\EchoerAdapter::class => -100,
+            Debug\Introspection\Response\EchoerAdapter::class => -100,
 
-        $container->register(Debug\Introspection\Request\VarDumperAdapter::class, Debug\Introspection\Request\VarDumperAdapter::class)
-            ->addTag(self::DEBUG_INTROSPECTION_TAG, ['priority' => -80])
-        ;
+            Debug\Introspection\Request\VarDumperAdapter::class => -80,
+            Debug\Introspection\Response\VarDumperAdapter::class => -80,
 
-        $container->register(Debug\Introspection\Request\VarDumper\JsonAdapter::class, Debug\Introspection\Request\VarDumper\JsonAdapter::class)
-            ->addTag(self::DEBUG_INTROSPECTION_TAG, ['priority' => -75])
-        ;
+            Debug\Introspection\Request\VarDumper\JsonAdapter::class => -75,
+            Debug\Introspection\Response\VarDumper\JsonAdapter::class => -75,
+        ];
 
-        $container->register(Debug\Introspection\Response\EchoerAdapter::class, Debug\Introspection\Response\EchoerAdapter::class)
-            ->addTag(self::DEBUG_INTROSPECTION_TAG, ['priority' => -100])
-        ;
-
-        $container->register(Debug\Introspection\Response\VarDumperAdapter::class, Debug\Introspection\Response\VarDumperAdapter::class)
-            ->addTag(self::DEBUG_INTROSPECTION_TAG, ['priority' => -80])
-        ;
-
-        $container->register(Debug\Introspection\Response\VarDumper\JsonAdapter::class, Debug\Introspection\Response\VarDumper\JsonAdapter::class)
-            ->addTag(self::DEBUG_INTROSPECTION_TAG, ['priority' => -70])
-        ;
+        foreach ($adapters as $adapter => $priority) {
+            $container->register($adapter, $adapter)
+                ->addTag(self::DEBUG_INTROSPECTION_TAG, ['priority' => $priority])
+            ;
+        }
     }
 }

--- a/src/Debug/CliController.php
+++ b/src/Debug/CliController.php
@@ -8,23 +8,14 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 
 use Behat\Testwork\Cli\Controller;
-use Behat\Testwork\Output\OutputManager;
 
 final class CliController implements Controller
 {
     /** @var Configuration */
     private $configuration;
 
-    /** @var OutputManager */
-    private $manager;
-
-    /** @var string Formatter's name to use on debug occasions */
-    private $formatter;
-
-    public function __construct(OutputManager $manager, Configuration $configuration, string $formatter = 'pretty')
+    public function __construct(Configuration $configuration)
     {
-        $this->manager = $manager;
-        $this->formatter = $formatter;
         $this->configuration = $configuration;
     }
 
@@ -39,11 +30,5 @@ final class CliController implements Controller
     public function execute(InputInterface $input, OutputInterface $output)
     {
         $this->configuration->setStatus($input->getOption('behapi-debug'));
-
-        if (true === $this->configuration->getStatus()) {
-            // disable all formatters, enable only the pretty one
-            $this->manager->disableAllFormatters();
-            $this->manager->enableFormatter($this->formatter);
-        }
     }
 }

--- a/src/Debug/Introspection/Adapter.php
+++ b/src/Debug/Introspection/Adapter.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+namespace Behapi\Debug\Introspection;
+
+use Psr\Http\Message\MessageInterface;
+
+interface Adapter
+{
+    /**
+     * Introspect useful information on a http message
+     *
+     * @param string[] $headers Headers to introspect
+     */
+    public function introspect(MessageInterface $message, array $headers): void;
+
+    /**
+     * Determines if this introspection supports the given http message
+     */
+    public function supports(MessageInterface $message): bool;
+}

--- a/src/Debug/Introspection/Request/EchoerAdapter.php
+++ b/src/Debug/Introspection/Request/EchoerAdapter.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types=1);
+namespace Behapi\Debug\Introspection\Request;
+
+use Psr\Http\Message\MessageInterface;
+use Psr\Http\Message\RequestInterface;
+
+use Behapi\Debug\Introspection;
+use Behapi\Debug\Introspection\Adapter;
+use Behapi\Debug\Introspection\UnsupportedMessage;
+
+final class EchoerAdapter implements Adapter
+{
+    // 1 - key
+    // 2 - value
+    private const TEMPLATE = "\033[36m| \033[1m%s : \033[0;36m%s\033[0m\n";
+
+    public function introspect(MessageInterface $message, array $headers): void
+    {
+        if (!$this->supports($message)) {
+            throw new UnsupportedMessage($message, RequestInterface::class);
+        }
+
+        echo "\n";
+
+        printf(self::TEMPLATE, 'Request', "{$message->getMethod()} {$message->getUri()}");
+
+        foreach ($headers as $header) {
+            printf(self::TEMPLATE, "Request {$header}", $message->getHeaderLine($header));
+        }
+
+        $body = (string) $message->getBody();
+
+        if (!empty($body)) {
+            echo "\n{$body}";
+        }
+
+        echo "\n";
+    }
+
+    public function supports(MessageInterface $message): bool
+    {
+        return $message instanceof RequestInterface;
+    }
+}

--- a/src/Debug/Introspection/Request/EchoerAdapter.php
+++ b/src/Debug/Introspection/Request/EchoerAdapter.php
@@ -20,6 +20,8 @@ final class EchoerAdapter implements Adapter
             throw new UnsupportedMessage($message, RequestInterface::class);
         }
 
+        assert($message instanceof RequestInterface);
+
         echo "\n";
 
         printf(self::TEMPLATE, 'Request', "{$message->getMethod()} {$message->getUri()}");

--- a/src/Debug/Introspection/Request/VarDumper/JsonAdapter.php
+++ b/src/Debug/Introspection/Request/VarDumper/JsonAdapter.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types=1);
+namespace Behapi\Debug\Introspection\Request\VarDumper;
+
+use Psr\Http\Message\MessageInterface;
+use Psr\Http\Message\RequestInterface;
+
+use Symfony\Component\VarDumper\VarDumper;
+
+use Behapi\Debug\Introspection\Adapter;
+use Behapi\Debug\Introspection\UnsupportedMessage;
+
+final class JsonAdapter implements Adapter
+{
+    public function introspect(MessageInterface $message, array $headers): void
+    {
+        if (!$this->supports($message)) {
+            throw new UnsupportedMessage($message, RequestInterface::class);
+        }
+
+        // mandatory, clearing the line
+        // todo : check how to clear without this echo...
+        echo "\n";
+
+        $dump = [
+            'Request' => "{$message->getMethod()} {$message->getUri()}",
+        ];
+
+        foreach ($headers as $header) {
+            $dump["Request {$header}"] = $message->getHeaderLine($header);
+        }
+
+        $body = (string) $message->getBody();
+
+        if (!empty($body)) {
+            $dump['Request Body'] = json_decode($body);
+        }
+
+        VarDumper::dump($dump);
+    }
+
+    public function supports(MessageInterface $message): bool
+    {
+        if (!class_exists(VarDumper::class)) {
+            return false;
+        }
+
+        if (!$message instanceof RequestInterface) {
+            return false;
+        }
+
+        [$contentType,] = explode(';', $message->getHeaderLine('Content-Type'), 2);
+
+        return 'application/json' === $contentType;
+    }
+}

--- a/src/Debug/Introspection/Request/VarDumper/JsonAdapter.php
+++ b/src/Debug/Introspection/Request/VarDumper/JsonAdapter.php
@@ -17,6 +17,8 @@ final class JsonAdapter implements Adapter
             throw new UnsupportedMessage($message, RequestInterface::class);
         }
 
+        assert($message instanceof RequestInterface);
+
         // mandatory, clearing the line
         // todo : check how to clear without this echo...
         echo "\n";

--- a/src/Debug/Introspection/Request/VarDumperAdapter.php
+++ b/src/Debug/Introspection/Request/VarDumperAdapter.php
@@ -17,6 +17,8 @@ final class VarDumperAdapter implements Adapter
             throw new UnsupportedMessage($message, RequestInterface::class);
         }
 
+        assert($message instanceof RequestInterface);
+
         // mandatory, clearing the line
         // todo : check how to clear without this echo...
         echo "\n";

--- a/src/Debug/Introspection/Request/VarDumperAdapter.php
+++ b/src/Debug/Introspection/Request/VarDumperAdapter.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types=1);
+namespace Behapi\Debug\Introspection\Request;
+
+use Psr\Http\Message\MessageInterface;
+use Psr\Http\Message\RequestInterface;
+
+use Symfony\Component\VarDumper\VarDumper;
+
+use Behapi\Debug\Introspection\Adapter;
+use Behapi\Debug\Introspection\UnsupportedMessage;
+
+final class VarDumperAdapter implements Adapter
+{
+    public function introspect(MessageInterface $message, array $headers): void
+    {
+        if (!$this->supports($message)) {
+            throw new UnsupportedMessage($message, RequestInterface::class);
+        }
+
+        // mandatory, clearing the line
+        // todo : check how to clear without this echo...
+        echo "\n";
+
+        $introspect = [
+            'Request' => "{$message->getMethod()} {$message->getUri()}",
+        ];
+
+        foreach ($headers as $header) {
+            $introspect["Request {$header}"] = $message->getHeaderLine($header);
+        }
+
+        $body = (string) $message->getBody();
+
+        if (!empty($body)) {
+            $introspect['Request Body'] = $body;
+        }
+
+        VarDumper::dump($introspect);
+    }
+
+    public function supports(MessageInterface $message): bool
+    {
+        return class_exists(VarDumper::class)
+            && $message instanceof RequestInterface
+        ;
+    }
+}

--- a/src/Debug/Introspection/Response/EchoerAdapter.php
+++ b/src/Debug/Introspection/Response/EchoerAdapter.php
@@ -19,6 +19,8 @@ final class EchoerAdapter implements Adapter
             throw new UnsupportedMessage($message, ResponseInterface::class);
         }
 
+        assert($message instanceof ResponseInterface);
+
         echo "\n";
 
         printf(self::TEMPLATE, 'Response status', "{$message->getStatusCode()} {$message->getReasonPhrase()}");

--- a/src/Debug/Introspection/Response/EchoerAdapter.php
+++ b/src/Debug/Introspection/Response/EchoerAdapter.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types=1);
+namespace Behapi\Debug\Introspection\Response;
+
+use Psr\Http\Message\MessageInterface;
+use Psr\Http\Message\ResponseInterface;
+
+use Behapi\Debug\Introspection\Adapter;
+use Behapi\Debug\Introspection\UnsupportedMessage;
+
+final class EchoerAdapter implements Adapter
+{
+    // 1 - key
+    // 2 - value
+    private const TEMPLATE = "\033[36m| \033[1m%s : \033[0;36m%s\033[0m\n";
+
+    public function introspect(MessageInterface $message, array $headers): void
+    {
+        if (!$this->supports($message)) {
+            throw new UnsupportedMessage($message, ResponseInterface::class);
+        }
+
+        echo "\n";
+
+        printf(self::TEMPLATE, 'Response status', "{$message->getStatusCode()} {$message->getReasonPhrase()}");
+
+        foreach ($headers as $header) {
+            printf(self::TEMPLATE, "Response {$header}", $message->getHeaderLine($header));
+        }
+
+        $body = (string) $message->getBody();
+
+        if (!empty($body)) {
+            echo "\n{$body}";
+        }
+
+        echo "\n";
+    }
+
+    public function supports(MessageInterface $message): bool
+    {
+        return $message instanceof ResponseInterface;
+    }
+}

--- a/src/Debug/Introspection/Response/VarDumper/JsonAdapter.php
+++ b/src/Debug/Introspection/Response/VarDumper/JsonAdapter.php
@@ -17,6 +17,8 @@ final class JsonAdapter implements Adapter
             throw new UnsupportedMessage($message, ResponseInterface::class);
         }
 
+        assert($message instanceof ResponseInterface);
+
         // mandatory, clearing the line
         // todo : check how to clear without this echo...
         echo "\n";

--- a/src/Debug/Introspection/Response/VarDumper/JsonAdapter.php
+++ b/src/Debug/Introspection/Response/VarDumper/JsonAdapter.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types=1);
+namespace Behapi\Debug\Introspection\Response\VarDumper;
+
+use Psr\Http\Message\MessageInterface;
+use Psr\Http\Message\ResponseInterface;
+
+use Symfony\Component\VarDumper\VarDumper;
+
+use Behapi\Debug\Introspection\Adapter;
+use Behapi\Debug\Introspection\UnsupportedMessage;
+
+final class JsonAdapter implements Adapter
+{
+    public function introspect(MessageInterface $message, array $headers): void
+    {
+        if (!$this->supports($message)) {
+            throw new UnsupportedMessage($message, ResponseInterface::class);
+        }
+
+        // mandatory, clearing the line
+        // todo : check how to clear without this echo...
+        echo "\n";
+
+        $dump = [
+            'Response Status' => "{$message->getStatusCode()} {$message->getReasonPhrase()}",
+        ];
+
+        foreach ($headers as $header) {
+            $dump["Response {$header}"] = $message->getHeaderLine($header);
+        }
+
+        $body = (string) $message->getBody();
+
+        if (!empty($body)) {
+            $dump['Response Body'] = json_decode($body);
+        }
+
+        VarDumper::dump($dump);
+    }
+
+    public function supports(MessageInterface $message): bool
+    {
+        if (!class_exists(VarDumper::class)) {
+            return false;
+        }
+
+        if (!$message instanceof ResponseInterface) {
+            return false;
+        }
+
+        [$contentType,] = explode(';', $message->getHeaderLine('Content-Type'), 2);
+
+        return 'application/json' === $contentType;
+    }
+}

--- a/src/Debug/Introspection/Response/VarDumperAdapter.php
+++ b/src/Debug/Introspection/Response/VarDumperAdapter.php
@@ -17,6 +17,8 @@ final class VarDumperAdapter implements Adapter
             throw new UnsupportedMessage($message, ResponseInterface::class);
         }
 
+        assert($message instanceof ResponseInterface);
+
         // mandatory, clearing the line
         // todo : check how to clear without this echo...
         echo "\n";

--- a/src/Debug/Introspection/Response/VarDumperAdapter.php
+++ b/src/Debug/Introspection/Response/VarDumperAdapter.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types=1);
+namespace Behapi\Debug\Introspection\Response;
+
+use Psr\Http\Message\MessageInterface;
+use Psr\Http\Message\ResponseInterface;
+
+use Symfony\Component\VarDumper\VarDumper;
+
+use Behapi\Debug\Introspection\Adapter;
+use Behapi\Debug\Introspection\UnsupportedMessage;
+
+final class VarDumperAdapter implements Adapter
+{
+    public function introspect(MessageInterface $message, array $headers): void
+    {
+        if (!$this->supports($message)) {
+            throw new UnsupportedMessage($message, ResponseInterface::class);
+        }
+
+        // mandatory, clearing the line
+        // todo : check how to clear without this echo...
+        echo "\n";
+
+        $introspect = [
+            'Response Status' => "{$message->getStatusCode()} {$message->getReasonPhrase()}",
+        ];
+
+        foreach ($headers as $header) {
+            $introspect["Response {$header}"] = $message->getHeaderLine($header);
+        }
+
+        $body = (string) $message->getBody();
+
+        if (!empty($body)) {
+            $introspect['Response Body'] = $body;
+        }
+
+        VarDumper::dump($introspect);
+    }
+
+    public function supports(MessageInterface $message): bool
+    {
+        return class_exists(VarDumper::class)
+            && $message instanceof ResponseInterface
+        ;
+    }
+}

--- a/src/Debug/Introspection/UnsupportedMessage.php
+++ b/src/Debug/Introspection/UnsupportedMessage.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+namespace Behapi\Debug\Introspection;
+
+use InvalidArgumentException;
+use Psr\Http\Message\MessageInterface;
+
+final class UnsupportedMessage extends InvalidArgumentException
+{
+    /* @var MessageInterface */
+    private $httpMessage;
+
+    public function __construct(MessageInterface $message, string $expected)
+    {
+        $this->httpMessage = $message;
+        $type = get_class($message);
+
+        parent::__construct("Wrong message type, expected {$expected}, got {$type}");
+    }
+
+    public function getHttpMessage(): MessageInterface
+    {
+        return $this->httpMessage;
+    }
+}

--- a/src/Debug/Listener.php
+++ b/src/Debug/Listener.php
@@ -17,6 +17,7 @@ use Behat\Behat\EventDispatcher\Event\GherkinNodeTested;
 
 use Behat\Gherkin\Node\TaggedNodeInterface;
 
+use Behapi\Debug\Introspection\Adapter;
 use Behapi\HttpHistory\History as HttpHistory;
 
 use function printf;
@@ -34,19 +35,20 @@ use function iterator_to_array;
  */
 final class Listener implements EventSubscriberInterface
 {
-    // 1 - key
-    // 2 - value
-    private const TEMPLATE = "\033[36m| \033[1m%s : \033[0;36m%s\033[0m\n";
-
     /** @var HttpHistory */
     private $history;
 
     /** @var Configuration */
     private $configuration;
 
-    public function __construct(Configuration $configuration, HttpHistory $history)
+    /* @var Adapter[] */
+    private $adapters;
+
+    /** @param Adapter[] $adapters Introspection adapters to use in this listener (sorted by priority) */
+    public function __construct(Configuration $configuration, HttpHistory $history, array $adapters)
     {
         $this->history = $history;
+        $this->adapters = $adapters;
         $this->configuration = $configuration;
     }
 
@@ -124,31 +126,25 @@ final class Listener implements EventSubscriberInterface
 
     private function debug(?RequestInterface $request, ?ResponseInterface $response): void
     {
-        if (!$request instanceof RequestInterface) {
-            return;
+        $messages = [
+            RequestInterface::class => $request,
+            ResponseInterface::class => $response,
+        ];
+
+        foreach ($messages as $interface => $message) {
+            if (!$message instanceof $interface) {
+                continue;
+            }
+
+            foreach ($this->adapters as $adapter) {
+                if (!$adapter->supports($message)) {
+                    continue;
+                }
+
+                $adapter->introspect($message, $this->configuration->getRequestHeaders());
+                break;
+            }
         }
-
-        printf(self::TEMPLATE, 'Request', "{$request->getMethod()} {$request->getUri()}");
-
-        foreach ($this->configuration->getRequestHeaders() as $header) {
-            printf(self::TEMPLATE, "Request {$header}", $request->getHeaderLine($header));
-        }
-
-        echo "\n";
-
-        if (!$response instanceof ResponseInterface) {
-            return;
-        }
-
-        printf(self::TEMPLATE, 'Response status', "{$response->getStatusCode()} {$response->getReasonPhrase()}");
-
-        foreach ($this->configuration->getResponseHeaders() as $header) {
-            printf(self::TEMPLATE, "Response {$header}", $response->getHeaderLine($header));
-        }
-
-        echo "\n";
-        echo (string) $response->getBody();
-        echo "\n";
     }
 
     private function hasTag(GherkinNodeTested $event, string $tag): bool

--- a/src/Debug/Listener.php
+++ b/src/Debug/Listener.php
@@ -1,6 +1,7 @@
 <?php declare(strict_types=1);
 namespace Behapi\Debug;
 
+use Psr\Http\Message\MessageInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
@@ -131,6 +132,7 @@ final class Listener implements EventSubscriberInterface
             ResponseInterface::class => $response,
         ];
 
+        /** @var MessageInterface $message */
         foreach ($messages as $interface => $message) {
             if (!$message instanceof $interface) {
                 continue;


### PR DESCRIPTION
So we can present it in another way, specially for json requests / responses...

![screenshot from 2018-04-08 23-45-06](https://user-images.githubusercontent.com/239685/38472890-031b3816-3b87-11e8-8221-ed6e8e39b41c.png)

Note : Finished but not finished yet. I'd like to inject a list of json headers (because only `application/json` doesn't cut it, as there are a shit-ton of variants..), but it should belong in another PR after this one is merged, as it would make sense to inject those in the json context too
