### PR TITLE
Enhance http history

### DIFF
--- a/src/Debug/Listener.php
+++ b/src/Debug/Listener.php
@@ -19,12 +19,11 @@ use Behat\Behat\EventDispatcher\Event\GherkinNodeTested;
 use Behat\Gherkin\Node\TaggedNodeInterface;
 
 use Behapi\Debug\Introspection\Adapter;
+
+use Behapi\HttpHistory\Tuple as HttpTuple;
 use Behapi\HttpHistory\History as HttpHistory;
 
-use function printf;
-use function current;
 use function method_exists;
-use function iterator_to_array;
 
 /**
  * Debug http
@@ -76,8 +75,8 @@ final class Listener implements EventSubscriberInterface
 
         // debug only if tag is present (all debug) or only on test failures
         if ($this->hasTag($event, 'debug')) {
-            foreach ($this->history as list($request, $response)) {
-                $this->debug($request, $response);
+            foreach ($this->history as $http) {
+                $this->debug($http);
             }
 
             return;
@@ -93,16 +92,16 @@ final class Listener implements EventSubscriberInterface
             return;
         }
 
-        foreach ($this->history as list($request, $response)) {
-            $this->debug($request, $response);
+        foreach ($this->history as $http) {
+            $this->debug($http);
         }
     }
 
-    private function debug(?RequestInterface $request, ?ResponseInterface $response): void
+    private function debug(HttpTuple $http): void
     {
         $messages = [
-            RequestInterface::class => $request,
-            ResponseInterface::class => $response,
+            RequestInterface::class => $http->getRequest(),
+            ResponseInterface::class => $http->getResponse(),
         ];
 
         /** @var MessageInterface $message */

--- a/src/Debug/Listener.php
+++ b/src/Debug/Listener.php
@@ -93,14 +93,8 @@ final class Listener implements EventSubscriberInterface
             return;
         }
 
-        foreach ([$result] as $testResult) {
-            if (TestResult::FAILED !== $testResult->getResultCode()) {
-                continue;
-            }
-
-            foreach ($this->history as list($request, $response)) {
-                $this->debug($request, $response);
-            }
+        foreach ($this->history as list($request, $response)) {
+            $this->debug($request, $response);
         }
     }
 

--- a/src/Debug/Listener.php
+++ b/src/Debug/Listener.php
@@ -76,12 +76,8 @@ final class Listener implements EventSubscriberInterface
 
         // debug only if tag is present (all debug) or only on test failures
         if ($this->hasTag($event, 'debug')) {
-            $tuples = current($this->history);
-
-            foreach ($tuples as $tuple) {
-                foreach ($tuple as list($request, $response)) {
-                    $this->debug($request, $response);
-                }
+            foreach ($this->history as list($request, $response)) {
+                $this->debug($request, $response);
             }
 
             return;
@@ -97,17 +93,13 @@ final class Listener implements EventSubscriberInterface
             return;
         }
 
-        $values = iterator_to_array($this->history);
-
         foreach ([$result] as $testResult) {
             if (TestResult::FAILED !== $testResult->getResultCode()) {
                 continue;
             }
 
-            foreach ($values as $tuples) {
-                foreach ($tuples as list($request, $response)) {
-                    $this->debug($request, $response);
-                }
+            foreach ($this->history as list($request, $response)) {
+                $this->debug($request, $response);
             }
         }
     }

--- a/src/HttpHistory/Listener.php
+++ b/src/HttpHistory/Listener.php
@@ -3,11 +3,8 @@ namespace Behapi\HttpHistory;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-use Behat\Testwork\EventDispatcher\Event\BeforeTested;
-
 use Behat\Behat\EventDispatcher\Event\ExampleTested;
 use Behat\Behat\EventDispatcher\Event\ScenarioTested;
-use Behat\Behat\EventDispatcher\Event\BackgroundTested;
 
 /**
  * Starts a new "section" in the HttpHistory object when a scenario-like is
@@ -20,9 +17,6 @@ final class Listener implements EventSubscriberInterface
     /** @var History */
     private $history;
 
-    /** @var bool */
-    private $inBackground = false;
-
     public function __construct(History $history)
     {
         $this->history = $history;
@@ -32,32 +26,14 @@ final class Listener implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return [
-            ExampleTested::BEFORE => 'start',
-            ScenarioTested::BEFORE => 'start',
-            BackgroundTested::BEFORE => 'start',
-
             ExampleTested::AFTER => ['clear', -99],
             ScenarioTested::AFTER => ['clear', -99],
         ];
-    }
-
-    public function start(BeforeTested $event, string $eventName): void
-    {
-        if ($this->inBackground === true) {
-            return;
-        }
-
-        if (BackgroundTested::BEFORE === $eventName) {
-            $this->inBackground = true;
-        }
-
-        $this->history->start();
     }
 
     /** Resets the current history of the current client */
     public function clear(): void
     {
         $this->history->reset();
-        $this->inBackground = false;
     }
 }

--- a/src/HttpHistory/Tuple.php
+++ b/src/HttpHistory/Tuple.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+namespace Behapi\HttpHistory;
+
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+final class Tuple
+{
+    /** @var RequestInterface */
+    private $request;
+
+    /** @var ?ResponseInterface */
+    private $response;
+
+    public function __construct(RequestInterface $request, ?ResponseInterface $response)
+    {
+        $this->request = $request;
+        $this->response = $response;
+    }
+
+    public function getRequest(): RequestInterface
+    {
+        return $this->request;
+    }
+
+    public function getResponse(): ?ResponseInterface
+    {
+        return $this->response;
+    }
+}


### PR DESCRIPTION
Remove a useless level on the top of the history object (it was useless, `start` was never called more than once per scenario / examples...), and transformed the resulting tuple into a `HttpTuple` object.

Removed also the iteration over `[$results]`, as this is a relic of the `Outline` case which is no more.

Overall, a simplification of the HttpHistory object. :}