### PR TITLE
Moar debug tweaks

### DIFF
--- a/src/Behapi.php
+++ b/src/Behapi.php
@@ -41,7 +41,7 @@ final class Behapi implements Extension
                 ->end()
 
                 ->arrayNode('debug')
-                    ->addDefaultsIfNotSet()
+                    ->canBeDisabled()
                     ->children()
                         ->scalarNode('formatter')
                             ->defaultValue('pretty')
@@ -130,6 +130,10 @@ final class Behapi implements Extension
 
     private function loadDebugServices(ContainerBuilder $container, array $config): void
     {
+        if (!$config['enabled']) {
+            return;
+        }
+
         $container->register(Debug\Status::class, Debug\Status::class)
             ->setPublic(false)
         ;

--- a/src/Behapi.php
+++ b/src/Behapi.php
@@ -49,17 +49,17 @@ final class Behapi implements Extension
                         ->end()
 
                         ->arrayNode('headers')
-                            ->info('Headers to print in Debug Http listener')
+                            ->info('Headers to print in Debug Http introspection adapters')
                             ->addDefaultsIfNotSet()
                             ->children()
                                 ->arrayNode('request')
-                                    ->info('Request headers to print in Debug Http listener')
+                                    ->info('Request headers to print in Debug Http introspection adapters')
                                     ->defaultValue(['Content-Type'])
                                     ->prototype('scalar')->end()
                                 ->end()
 
                                 ->arrayNode('response')
-                                    ->info('Response headers to print in Debug Http listener')
+                                    ->info('Response headers to print in Debug Http introspection adapters')
                                     ->defaultValue(['Content-Type'])
                                     ->prototype('scalar')->end()
                                 ->end()
@@ -131,9 +131,6 @@ final class Behapi implements Extension
     private function loadDebugServices(ContainerBuilder $container, array $config): void
     {
         $container->register(Debug\Configuration::class, Debug\Configuration::class)
-            ->addArgument($config['headers']['request'])
-            ->addArgument($config['headers']['response'])
-
             ->setPublic(false)
         ;
 
@@ -153,18 +150,19 @@ final class Behapi implements Extension
         ;
 
         $adapters = [
-            Debug\Introspection\Request\EchoerAdapter::class => -100,
-            Debug\Introspection\Response\EchoerAdapter::class => -100,
+            Debug\Introspection\Request\EchoerAdapter::class => [-100, $config['headers']['request']],
+            Debug\Introspection\Response\EchoerAdapter::class => [-100, $config['headers']['response']],
 
-            Debug\Introspection\Request\VarDumperAdapter::class => -80,
-            Debug\Introspection\Response\VarDumperAdapter::class => -80,
+            Debug\Introspection\Request\VarDumperAdapter::class => [-80, $config['headers']['request']],
+            Debug\Introspection\Response\VarDumperAdapter::class => [-80, $config['headers']['response']],
 
-            Debug\Introspection\Request\VarDumper\JsonAdapter::class => -75,
-            Debug\Introspection\Response\VarDumper\JsonAdapter::class => -75,
+            Debug\Introspection\Request\VarDumper\JsonAdapter::class => [-75, $config['headers']['request']],
+            Debug\Introspection\Response\VarDumper\JsonAdapter::class => [-75, $config['headers']['response']],
         ];
 
-        foreach ($adapters as $adapter => $priority) {
+        foreach ($adapters as $adapter => [$priority, $headers]) {
             $container->register($adapter, $adapter)
+                ->addArgument($headers)
                 ->addTag(self::DEBUG_INTROSPECTION_TAG, ['priority' => $priority])
             ;
         }

--- a/src/Behapi.php
+++ b/src/Behapi.php
@@ -130,19 +130,19 @@ final class Behapi implements Extension
 
     private function loadDebugServices(ContainerBuilder $container, array $config): void
     {
-        $container->register(Debug\Configuration::class, Debug\Configuration::class)
+        $container->register(Debug\Status::class, Debug\Status::class)
             ->setPublic(false)
         ;
 
         $container->register(Debug\CliController::class, Debug\CliController::class)
-            ->addArgument(new Reference(Debug\Configuration::class))
+            ->addArgument(new Reference(Debug\Status::class))
 
             ->setPublic(false)
             ->addTag(CliExtension::CONTROLLER_TAG, ['priority' => 10])
         ;
 
         $container->register(Debug\Listener::class, Debug\Listener::class)
-            ->addArgument(new Reference(Debug\Configuration::class))
+            ->addArgument(new Reference(Debug\Status::class))
             ->addArgument(new Reference(HttpHistory\History::class))
 
             ->setPublic(false)

--- a/src/Debug/CliController.php
+++ b/src/Debug/CliController.php
@@ -11,12 +11,12 @@ use Behat\Testwork\Cli\Controller;
 
 final class CliController implements Controller
 {
-    /** @var Configuration */
-    private $configuration;
+    /** @var Status */
+    private $status;
 
-    public function __construct(Configuration $configuration)
+    public function __construct(Status $status)
     {
-        $this->configuration = $configuration;
+        $this->status = $status;
     }
 
     /** {@inheritDoc} */
@@ -29,6 +29,6 @@ final class CliController implements Controller
     /** {@inheritDoc} */
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        $this->configuration->setStatus($input->getOption('behapi-debug'));
+        $this->status->setEnabled($input->getOption('behapi-debug'));
     }
 }

--- a/src/Debug/Configuration.php
+++ b/src/Debug/Configuration.php
@@ -11,18 +11,6 @@ final class Configuration
     /** @var bool */
     private $status = false;
 
-    /** @var string[] Request headers to print when debugging */
-    private $requestHeaders = [];
-
-    /** @var string[] Response headers to print when debugging */
-    private $responseHeaders = [];
-
-    public function __construct(array $requestHeaders, array $responseHeaders)
-    {
-        $this->requestHeaders = $requestHeaders;
-        $this->responseHeaders = $responseHeaders;
-    }
-
     public function setStatus(bool $status)
     {
         $this->status = $status;
@@ -31,15 +19,5 @@ final class Configuration
     public function getStatus(): bool
     {
         return $this->status;
-    }
-
-    public function getRequestHeaders(): array
-    {
-        return $this->requestHeaders;
-    }
-
-    public function getResponseHeaders(): array
-    {
-        return $this->responseHeaders;
     }
 }

--- a/src/Debug/Introspection/Adapter.php
+++ b/src/Debug/Introspection/Adapter.php
@@ -7,10 +7,8 @@ interface Adapter
 {
     /**
      * Introspect useful information on a http message
-     *
-     * @param string[] $headers Headers to introspect
      */
-    public function introspect(MessageInterface $message, array $headers): void;
+    public function introspect(MessageInterface $message): void;
 
     /**
      * Determines if this introspection supports the given http message

--- a/src/Debug/Introspection/Request/EchoerAdapter.php
+++ b/src/Debug/Introspection/Request/EchoerAdapter.php
@@ -14,7 +14,16 @@ final class EchoerAdapter implements Adapter
     // 2 - value
     private const TEMPLATE = "\033[36m| \033[1m%s : \033[0;36m%s\033[0m\n";
 
-    public function introspect(MessageInterface $message, array $headers): void
+    /** @var iterable<string> */
+    private $headers;
+
+    /** @param iterable<string> $headers */
+    public function __construct(iterable $headers)
+    {
+        $this->headers = $headers;
+    }
+
+    public function introspect(MessageInterface $message): void
     {
         if (!$this->supports($message)) {
             throw new UnsupportedMessage($message, RequestInterface::class);
@@ -26,7 +35,7 @@ final class EchoerAdapter implements Adapter
 
         printf(self::TEMPLATE, 'Request', "{$message->getMethod()} {$message->getUri()}");
 
-        foreach ($headers as $header) {
+        foreach ($this->headers as $header) {
             printf(self::TEMPLATE, "Request {$header}", $message->getHeaderLine($header));
         }
 

--- a/src/Debug/Introspection/Request/VarDumper/JsonAdapter.php
+++ b/src/Debug/Introspection/Request/VarDumper/JsonAdapter.php
@@ -11,7 +11,16 @@ use Behapi\Debug\Introspection\UnsupportedMessage;
 
 final class JsonAdapter implements Adapter
 {
-    public function introspect(MessageInterface $message, array $headers): void
+    /** @var iterable<string> */
+    private $headers;
+
+    /** @param iterable<string> $headers */
+    public function __construct(iterable $headers)
+    {
+        $this->headers = $headers;
+    }
+
+    public function introspect(MessageInterface $message): void
     {
         if (!$this->supports($message)) {
             throw new UnsupportedMessage($message, RequestInterface::class);
@@ -27,7 +36,7 @@ final class JsonAdapter implements Adapter
             'Request' => "{$message->getMethod()} {$message->getUri()}",
         ];
 
-        foreach ($headers as $header) {
+        foreach ($this->headers as $header) {
             $dump["Request {$header}"] = $message->getHeaderLine($header);
         }
 

--- a/src/Debug/Introspection/Request/VarDumper/JsonAdapter.php
+++ b/src/Debug/Introspection/Request/VarDumper/JsonAdapter.php
@@ -9,14 +9,20 @@ use Symfony\Component\VarDumper\VarDumper;
 use Behapi\Debug\Introspection\Adapter;
 use Behapi\Debug\Introspection\UnsupportedMessage;
 
+use function in_array;
+
 final class JsonAdapter implements Adapter
 {
     /** @var iterable<string> */
     private $headers;
 
+    /** @var string[] */
+    private $types;
+
     /** @param iterable<string> $headers */
-    public function __construct(iterable $headers)
+    public function __construct(iterable $headers, array $types)
     {
+        $this->types = $types;
         $this->headers = $headers;
     }
 
@@ -61,6 +67,6 @@ final class JsonAdapter implements Adapter
 
         [$contentType,] = explode(';', $message->getHeaderLine('Content-Type'), 2);
 
-        return 'application/json' === $contentType;
+        return in_array($contentType, $this->types, true);
     }
 }

--- a/src/Debug/Introspection/Request/VarDumperAdapter.php
+++ b/src/Debug/Introspection/Request/VarDumperAdapter.php
@@ -11,7 +11,16 @@ use Behapi\Debug\Introspection\UnsupportedMessage;
 
 final class VarDumperAdapter implements Adapter
 {
-    public function introspect(MessageInterface $message, array $headers): void
+    /** @var iterable<string> */
+    private $headers;
+
+    /** @param iterable<string> $headers */
+    public function __construct(iterable $headers)
+    {
+        $this->headers = $headers;
+    }
+
+    public function introspect(MessageInterface $message): void
     {
         if (!$this->supports($message)) {
             throw new UnsupportedMessage($message, RequestInterface::class);
@@ -27,7 +36,7 @@ final class VarDumperAdapter implements Adapter
             'Request' => "{$message->getMethod()} {$message->getUri()}",
         ];
 
-        foreach ($headers as $header) {
+        foreach ($this->headers as $header) {
             $introspect["Request {$header}"] = $message->getHeaderLine($header);
         }
 

--- a/src/Debug/Introspection/Response/EchoerAdapter.php
+++ b/src/Debug/Introspection/Response/EchoerAdapter.php
@@ -13,7 +13,16 @@ final class EchoerAdapter implements Adapter
     // 2 - value
     private const TEMPLATE = "\033[36m| \033[1m%s : \033[0;36m%s\033[0m\n";
 
-    public function introspect(MessageInterface $message, array $headers): void
+    /** @var iterable<string> */
+    private $headers;
+
+    /** @param iterable<string> $headers */
+    public function __construct(iterable $headers)
+    {
+        $this->headers = $headers;
+    }
+
+    public function introspect(MessageInterface $message): void
     {
         if (!$this->supports($message)) {
             throw new UnsupportedMessage($message, ResponseInterface::class);
@@ -25,7 +34,7 @@ final class EchoerAdapter implements Adapter
 
         printf(self::TEMPLATE, 'Response status', "{$message->getStatusCode()} {$message->getReasonPhrase()}");
 
-        foreach ($headers as $header) {
+        foreach ($this->headers as $header) {
             printf(self::TEMPLATE, "Response {$header}", $message->getHeaderLine($header));
         }
 

--- a/src/Debug/Introspection/Response/VarDumper/JsonAdapter.php
+++ b/src/Debug/Introspection/Response/VarDumper/JsonAdapter.php
@@ -11,7 +11,16 @@ use Behapi\Debug\Introspection\UnsupportedMessage;
 
 final class JsonAdapter implements Adapter
 {
-    public function introspect(MessageInterface $message, array $headers): void
+    /** @var iterable<string> */
+    private $headers;
+
+    /** @param iterable<string> $headers */
+    public function __construct(iterable $headers)
+    {
+        $this->headers = $headers;
+    }
+
+    public function introspect(MessageInterface $message): void
     {
         if (!$this->supports($message)) {
             throw new UnsupportedMessage($message, ResponseInterface::class);
@@ -27,7 +36,7 @@ final class JsonAdapter implements Adapter
             'Response Status' => "{$message->getStatusCode()} {$message->getReasonPhrase()}",
         ];
 
-        foreach ($headers as $header) {
+        foreach ($this->headers as $header) {
             $dump["Response {$header}"] = $message->getHeaderLine($header);
         }
 

--- a/src/Debug/Introspection/Response/VarDumper/JsonAdapter.php
+++ b/src/Debug/Introspection/Response/VarDumper/JsonAdapter.php
@@ -9,14 +9,20 @@ use Symfony\Component\VarDumper\VarDumper;
 use Behapi\Debug\Introspection\Adapter;
 use Behapi\Debug\Introspection\UnsupportedMessage;
 
+use function in_array;
+
 final class JsonAdapter implements Adapter
 {
     /** @var iterable<string> */
     private $headers;
 
+    /** @var string[] */
+    private $types;
+
     /** @param iterable<string> $headers */
-    public function __construct(iterable $headers)
+    public function __construct(iterable $headers, array $types)
     {
+        $this->types = $types;
         $this->headers = $headers;
     }
 
@@ -61,6 +67,6 @@ final class JsonAdapter implements Adapter
 
         [$contentType,] = explode(';', $message->getHeaderLine('Content-Type'), 2);
 
-        return 'application/json' === $contentType;
+        return in_array($contentType, $this->types, true);
     }
 }

--- a/src/Debug/Introspection/Response/VarDumperAdapter.php
+++ b/src/Debug/Introspection/Response/VarDumperAdapter.php
@@ -11,7 +11,16 @@ use Behapi\Debug\Introspection\UnsupportedMessage;
 
 final class VarDumperAdapter implements Adapter
 {
-    public function introspect(MessageInterface $message, array $headers): void
+    /** @var iterable<string> */
+    private $headers;
+
+    /** @param iterable<string> $headers */
+    public function __construct(iterable $headers)
+    {
+        $this->headers = $headers;
+    }
+
+    public function introspect(MessageInterface $message): void
     {
         if (!$this->supports($message)) {
             throw new UnsupportedMessage($message, ResponseInterface::class);
@@ -27,7 +36,7 @@ final class VarDumperAdapter implements Adapter
             'Response Status' => "{$message->getStatusCode()} {$message->getReasonPhrase()}",
         ];
 
-        foreach ($headers as $header) {
+        foreach ($this->headers as $header) {
             $introspect["Response {$header}"] = $message->getHeaderLine($header);
         }
 

--- a/src/Debug/Listener.php
+++ b/src/Debug/Listener.php
@@ -37,18 +37,18 @@ final class Listener implements EventSubscriberInterface
     /** @var HttpHistory */
     private $history;
 
-    /** @var Configuration */
-    private $configuration;
+    /** @var Status */
+    private $status;
 
     /* @var Adapter[] */
     private $adapters;
 
     /** @param Adapter[] $adapters Introspection adapters to use in this listener (sorted by priority) */
-    public function __construct(Configuration $configuration, HttpHistory $history, array $adapters)
+    public function __construct(Status $status, HttpHistory $history, array $adapters)
     {
         $this->history = $history;
         $this->adapters = $adapters;
-        $this->configuration = $configuration;
+        $this->status = $status;
     }
 
     /** {@inheritDoc} */
@@ -80,7 +80,7 @@ final class Listener implements EventSubscriberInterface
             return;
         }
 
-        if (false === $this->configuration->getStatus()) {
+        if (false === $this->status->isEnabled()) {
             return;
         }
 

--- a/src/Debug/Listener.php
+++ b/src/Debug/Listener.php
@@ -113,7 +113,7 @@ final class Listener implements EventSubscriberInterface
                     continue;
                 }
 
-                $adapter->introspect($message, $this->configuration->getRequestHeaders());
+                $adapter->introspect($message);
                 break;
             }
         }

--- a/src/Debug/Status.php
+++ b/src/Debug/Status.php
@@ -6,18 +6,18 @@ namespace Behapi\Debug;
  *
  * @author Baptiste Clavié <clavie.b@gmail.com>
  */
-final class Configuration
+final class Status
 {
     /** @var bool */
-    private $status = false;
+    private $enabled = false;
 
-    public function setStatus(bool $status)
+    public function setEnabled(bool $enabled)
     {
-        $this->status = $status;
+        $this->enabled = $enabled;
     }
 
-    public function getStatus(): bool
+    public function isEnabled(): bool
     {
-        return $this->status;
+        return $this->enabled;
     }
 }


### PR DESCRIPTION
Move the headers out of the debug configuration object directly into the introspection adapters, so that they are free to dump whatever headers they need to. Renamed the configuration object into a status object.

Allow to check a broader range of types for the json var-dumper introspection adapter. :}