### PR TITLE
Json : inject content types in constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Behapi
 ======
 Behat extension to help write describe features related to HTTP APIs.
 
-PHP 7.1, Behat 3.4, and a discoverable php-http client are required to make
+PHP 7.1, Behat 3.5, and a discoverable php-http client are required to make
 this extension work.
 
 Installing this extension is pretty easy, and there are multiple ways to do

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
     },
 
     "conflict": {
-        "behat/behat": "< 3.4",
+        "behat/behat": "< 3.5",
         "symfony/dependency-injection": "< 2.8"
     },
 
@@ -51,7 +51,7 @@
     "minimum-stability": "dev",
 
     "require-dev": {
-        "behat/behat": "^3.4",
+        "behat/behat": "^3.5",
 
         "nyholm/psr7": "^1.0",
         "coduo/php-matcher": "^2.3 || ^3.0",

--- a/src/Json/Context.php
+++ b/src/Json/Context.php
@@ -21,20 +21,20 @@ class Context extends AbstractContext
     /** @var HttpHistory */
     private $history;
 
-    public function __construct(HttpHistory $history)
+    /** @var string[] */
+    private $contentTypes;
+
+    public function __construct(HttpHistory $history, array $contentTypes = ['application/json'])
     {
         parent::__construct();
+
         $this->history = $history;
+        $this->contentTypes = $contentTypes;
     }
 
     protected function getJson()
     {
         return json_decode((string) $this->history->getLastResponse()->getBody());
-    }
-
-    protected function getContentTypes(): array
-    {
-        return ['application/json'];
     }
 
     /**
@@ -53,6 +53,6 @@ class Context extends AbstractContext
         [$contentType,] = explode(';', $this->history->getLastResponse()->getHeaderLine('Content-Type'), 2);
 
         Assert::same(JSON_ERROR_NONE, json_last_error(), sprintf('The response is not a valid json (%s)', json_last_error_msg()));
-        Assert::oneOf($contentType, $this->getContentTypes(), 'The response should have a valid content-type (expected one of %2$s, got %1$s)');
+        Assert::oneOf($contentType, $this->contentTypes, 'The response should have a valid content-type (expected one of %2$s, got %1$s)');
     }
 }


### PR DESCRIPTION
Rather than using a public static method, so that the json context can be moar configurable without having to extend it. :}

Little BC break though, as I removed the method and it is not called anymore in the json context.