### PR TITLE
Refactor plugin client builder

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -28,6 +28,13 @@ final class Container implements ContainerInterface
     /** @var string BaseURL for api requests */
     private $baseUrl;
 
+    private const SERVICES = [
+        HttpHistory::class,
+        PluginClientBuilder::class,
+        StreamFactoryInterface::class,
+        RequestFactoryInterface::class,
+    ];
+
     public function __construct(HttpHistory $history, string $baseUrl)
     {
         $this->baseUrl = $baseUrl;
@@ -36,14 +43,7 @@ final class Container implements ContainerInterface
 
     public function has($id)
     {
-        static $services = [
-            HttpHistory::class,
-            PluginClientBuilder::class,
-            StreamFactoryInterface::class,
-            RequestFactoryInterface::class,
-        ];
-
-        return in_array($id, $services, true);
+        return in_array($id, self::SERVICES, true);
     }
 
     public function get($id)
@@ -75,10 +75,9 @@ final class Container implements ContainerInterface
 
         assert($this->services[HttpHistory::class] instanceof HttpHistory);
 
-        // use randomized strings so that these cannot be removed (safety)
-        $builder->addPlugin(new ContentLengthPlugin);
-        $builder->addPlugin(new BaseUriPlugin($baseUri));
-        $builder->addPlugin(new HistoryPlugin($this->services[HttpHistory::class]));
+        $builder = $builder->addPlugin(new ContentLengthPlugin);
+        $builder = $builder->addPlugin(new BaseUriPlugin($baseUri));
+        $builder = $builder->addPlugin(new HistoryPlugin($this->services[HttpHistory::class]));
 
         return $builder;
     }

--- a/src/Container.php
+++ b/src/Container.php
@@ -17,9 +17,7 @@ use Http\Discovery\Psr17FactoryDiscovery;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 
-use function bin2hex;
 use function in_array;
-use function random_bytes;
 use function array_key_exists;
 
 final class Container implements ContainerInterface
@@ -78,9 +76,9 @@ final class Container implements ContainerInterface
         assert($this->services[HttpHistory::class] instanceof HttpHistory);
 
         // use randomized strings so that these cannot be removed (safety)
-        $builder->addPlugin(bin2hex(random_bytes(10)), new ContentLengthPlugin);
-        $builder->addPlugin(bin2hex(random_bytes(10)), new BaseUriPlugin($baseUri));
-        $builder->addPlugin(bin2hex(random_bytes(10)), new HistoryPlugin($this->services[HttpHistory::class]));
+        $builder->addPlugin(new ContentLengthPlugin);
+        $builder->addPlugin(new BaseUriPlugin($baseUri));
+        $builder->addPlugin(new HistoryPlugin($this->services[HttpHistory::class]));
 
         return $builder;
     }

--- a/src/Http/PluginClientBuilder.php
+++ b/src/Http/PluginClientBuilder.php
@@ -19,18 +19,23 @@ final class PluginClientBuilder
     /** @var array Array of options to give to the plugin client */
     private $options = [];
 
+    /** @var ?PluginClient */
+    private $client = null;
+
     /** @param int $priority Priority of the plugin. The higher comes first. */
     public function addPlugin(Plugin $plugin, int $priority = 0): self
     {
         $this->plugins[$priority][] = $plugin;
+        $this->client = null;
 
         return $this;
     }
 
     /** @param mixed $value */
-    public function setOption(string $name, $value): self
+    public function addOption(string $name, $value): self
     {
         $this->options[$name] = $value;
+        $this->client = null;
 
         return $this;
     }
@@ -38,12 +43,20 @@ final class PluginClientBuilder
     public function removeOption(string $name): self
     {
         unset($this->options[$name]);
+        $this->client = null;
 
         return $this;
     }
 
-    public function createClient(ClientInterface $client): PluginClient
+    public function createClient(ClientInterface $httpClient): PluginClient
     {
+        static $client;
+
+        if ($client === $httpClient && $this->client !== null) {
+            return $this->client;
+        }
+
+        $client = $httpClient;
         $plugins = $this->plugins;
 
         if (0 === count($plugins)) {
@@ -53,8 +66,8 @@ final class PluginClientBuilder
         krsort($plugins);
         $plugins = array_merge(...$plugins);
 
-        return new PluginClient(
-            $client,
+        return $this->client = new PluginClient(
+            $httpClient,
             array_values($plugins),
             $this->options
         );

--- a/src/Http/RequestContext.php
+++ b/src/Http/RequestContext.php
@@ -11,7 +11,7 @@ use Psr\Http\Message\StreamFactoryInterface;
 use Behat\Behat\Context\Context;
 use Behat\Gherkin\Node\TableNode;
 
-use Http\Discovery\HttpClientDiscovery;
+use Http\Discovery\Psr18ClientDiscovery;
 
 use function trim;
 use function is_array;
@@ -43,7 +43,7 @@ class RequestContext implements Context
         $this->streamFactory = $streamFactory;
         $this->requestFactory = $requestFactory;
 
-        $this->client = HttpClientDiscovery::find();
+        $this->client = Psr18ClientDiscovery::find();
     }
 
     /** @When /^I create a "(?P<method>GET|POST|PATCH|PUT|DELETE|OPTIONS|HEAD)" request to "(?P<url>.+?)"$/ */


### PR DESCRIPTION
As the job was done on the upstream (not yet released though), using the same api makes sense.

I will still need to overwrite it to add the cache capabilities though (creating a plugin client for each request doesn't look optimal, especially for 1000s+ tests)