### PR TITLE
Add new step for easier graphql query

### DIFF
--- a/src/Http/RequestContext.php
+++ b/src/Http/RequestContext.php
@@ -37,11 +37,15 @@ class RequestContext implements Context
     /** @var RequestFactoryInterface */
     private $requestFactory;
 
-    public function __construct(PluginClientBuilder $builder, StreamFactoryInterface $streamFactory, RequestFactoryInterface $requestFactory)
+    /** @var string */
+    private $graphqlEndpoint;
+
+    public function __construct(PluginClientBuilder $builder, StreamFactoryInterface $streamFactory, RequestFactoryInterface $requestFactory, string $graphqlEndpoint = '')
     {
         $this->builder = $builder;
         $this->streamFactory = $streamFactory;
         $this->requestFactory = $requestFactory;
+        $this->graphqlEndpoint = $graphqlEndpoint;
 
         $this->client = Psr18ClientDiscovery::find();
     }
@@ -115,6 +119,24 @@ class RequestContext implements Context
         $stream = $this->streamFactory->createStream($body);
 
         $request = $this->getRequest();
+        $this->request = $request->withBody($stream);
+    }
+
+    /** @When I create the following graphql request: */
+    final public function set_the_graphql_body(string $body): void
+    {
+        if (empty($this->graphqlEndpoint)) {
+            throw new RuntimeException('No graphql endpoint specified');
+        }
+
+        $this->query = [];
+        $request = $this->requestFactory->createRequest('POST', $this->graphqlEndpoint);
+
+        // let's set a default content-type
+        $this->set_the_content_type($this->getDefaultContentType());
+
+        $stream = $this->streamFactory->createStream(json_encode(['query' => $body]));
+
         $this->request = $request->withBody($stream);
     }
 


### PR DESCRIPTION
Add a step that by default set the method to post and the route for the request to /graphql.

Also Json encode the query into the graphQl wrapper.