### PR TITLE
fix: nullable parameter order in the Json Context for php 8.1

### DIFF
--- a/src/Json/Context.php
+++ b/src/Json/Context.php
@@ -80,7 +80,7 @@ class Context implements BehatContext
      * @Then in the json, :path should be equal to :expected
      * @Then in the json, :path should :not be equal to :expected
      */
-    final public function the_json_path_should_be_equal_to(string $path, ?string $not = null, $expected): void
+    final public function the_json_path_should_be_equal_to(string $path, $expected, ?string $not = null): void
     {
         $assert = Assert::that($this->getValue($path));
 
@@ -112,7 +112,7 @@ class Context implements BehatContext
      * @Then /^in the json, "(?P<path>(?:[^"]|\\")*)" should be (?P<expected>true|false)$/
      * @Then /^in the json, "(?P<path>(?:[^"]|\\")*)" should :not be (?P<expected>true|false)$/
      */
-    final public function the_json_path_should_be(string $path, ?string $not = null, string $expected): void
+    final public function the_json_path_should_be(string $path, string $expected, ?string $not = null): void
     {
         $assert = Assert::that($this->getValue($path));
 
@@ -162,7 +162,7 @@ class Context implements BehatContext
      * @Then in the json, :path should contain :expected
      * @Then in the json, :path should :not contain :expected
      */
-    final public function the_json_path_contains(string $path, ?string $not = null, $expected): void
+    final public function the_json_path_contains(string $path, $expected, ?string $not = null): void
     {
         $assert = Assert::that($this->getValue($path));
 
@@ -254,7 +254,7 @@ class Context implements BehatContext
      *  @Then in the json, :path should match :pattern
      *  @Then in the json, :path should :not match :pattern
      */
-    final public function the_json_path_should_match(string $path, ?string $not = null, string $pattern): void
+    final public function the_json_path_should_match(string $path, string $pattern, ?string $not = null): void
     {
         $assert = Assert::that($this->getValue($path));
 


### PR DESCRIPTION
Prior to PHP 8.1, the method isDefaultValueAvailable() on optional parameter declared before a required parameter would return true. That not the case anymore with php 8.1.
See https://onlinephp.io/c/3c36e

As it's something used by Behat to construct arguments of a step, it breaks as Behat doesn't add the argument anymore (see  https://github.com/Behat/Behat/blob/master/src/Behat/Testwork/Argument/MixedArgumentOrganiser.php#L408).
In the Json context of Behapi (and probably elsewhere, didn't check everything), there is nullable parameter before required parameter.
`final public function the_json_path_should_be_equal_to(string $path, ?string $not = null, $expected): void`

I didn't touch the the_json_path_should_be_py_string because I think multiline argument are always passed as the last argument in Behat. So a rewrite or a split of the function is needed.
